### PR TITLE
Improve package completion in various document states

### DIFF
--- a/src/ProjectFileTools/Completion/PackageCompletionSource.cs
+++ b/src/ProjectFileTools/Completion/PackageCompletionSource.cs
@@ -39,7 +39,7 @@ namespace ProjectFileTools.Completion
             textBuffer.Properties.AddProperty(typeof(PackageCompletionSource), this);
         }
 
-        private static bool TryGetExtents(ITextSnapshot snapshot, int pos, 
+        private static bool TryGetExtents(ITextSnapshot snapshot, int pos,
             out string documentText, out int start, out int end, out int startQuote, out int endQuote,
             out int realEnd, out bool isHealed, out string healedXml)
         {
@@ -222,6 +222,7 @@ namespace ProjectFileTools.Completion
             XAttribute name = element.Attribute(XName.Get("Include"));
             XAttribute version = element.Attribute(XName.Get("Version"));
             newText = healedXml;
+            string attributeText = healedXml.Substring(startQuote + 1 - start, endQuote - startQuote - 1);
 
             if (version == null)
             {
@@ -237,7 +238,7 @@ namespace ProjectFileTools.Completion
             int versionIndex = newText.IndexOf("Version");
             int quoteIndex = newText.IndexOf('"', versionIndex);
             int proposedPos = start + quoteIndex + 1;
-            bool move = pos < proposedPos;
+            bool move = version.Value != attributeText;
             pos = proposedPos;
             targetSpan = new Span(start, realEnd - start + 1);
             return move;
@@ -245,7 +246,7 @@ namespace ProjectFileTools.Completion
 
         public static bool IsInRangeForPackageCompletion(ITextSnapshot snapshot, int pos, out Span span, out string packageName, out string packageVersion, out string completionType)
         {
-            if(pos < 1)
+            if (pos < 1)
             {
                 span = default(Span);
                 packageName = null;
@@ -344,7 +345,7 @@ namespace ProjectFileTools.Completion
             if (_isSelfTrigger)
             {
                 _isSelfTrigger = false;
-                if(_currentCompletionSet != null)
+                if (_currentCompletionSet != null)
                 {
                     completionSets.Add(_currentCompletionSet);
                 }
@@ -438,9 +439,9 @@ namespace ProjectFileTools.Completion
             List<Microsoft.VisualStudio.Language.Intellisense.Completion> completions = new List<Microsoft.VisualStudio.Language.Intellisense.Completion>();
             Dictionary<string, FeedKind> packageLookup = new Dictionary<string, FeedKind>();
 
-            foreach(Tuple<string, FeedKind> info in _nameSearchJob.Results)
+            foreach (Tuple<string, FeedKind> info in _nameSearchJob.Results)
             {
-                if(!packageLookup.TryGetValue(info.Item1, out FeedKind existingInfo) || info.Item2 == FeedKind.Local)
+                if (!packageLookup.TryGetValue(info.Item1, out FeedKind existingInfo) || info.Item2 == FeedKind.Local)
                 {
                     packageLookup[info.Item1] = info.Item2;
                 }

--- a/src/ProjectFileTools/Completion/PackageIntellisenseControllerProvider.cs
+++ b/src/ProjectFileTools/Completion/PackageIntellisenseControllerProvider.cs
@@ -27,15 +27,7 @@ namespace ProjectFileTools.Completion
 
         public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers)
         {
-            string text = textView.TextBuffer.CurrentSnapshot.GetText();
-            bool isCore = text.IndexOf("Microsoft.Net.Sdk", StringComparison.OrdinalIgnoreCase) > -1;
-
-            if (isCore)
-            {
-                return new PackageIntellisenseController(textView, subjectBuffers, CompletionBroker);
-            }
-
-            return null;
+            return new PackageIntellisenseController(textView, subjectBuffers, CompletionBroker);
         }
     }
 }

--- a/src/ProjectFileTools/Helpers/XmlInfo.cs
+++ b/src/ProjectFileTools/Helpers/XmlInfo.cs
@@ -1,0 +1,74 @@
+﻿using System.Xml.Linq;
+
+namespace ProjectFileTools.Helpers
+{
+    public class XmlInfo
+    {
+        public XmlInfo(string originalText, string elementText, int start, int end, int startQuote, int endQuote, bool isModified, int realEnd, string elementName, string attributeName)
+        {
+            OriginalText = originalText;
+            ElementText = elementText;
+            TagStart = start;
+            TagEnd = end;
+            AttributeQuoteStart = startQuote;
+            AttributeQuoteEnd = endQuote;
+            IsModified = isModified;
+            EndInActualDocument = realEnd;
+            TagName = elementName;
+            AttributeName = attributeName;
+        }
+
+        public bool TryGetElement(out XElement element)
+        {
+            try
+            {
+                element = XElement.Parse(ElementText);
+            }
+            catch
+            {
+                element = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        public int TagStart { get; }
+
+        public int TagEnd { get; }
+
+        public int AttributeQuoteStart { get; }
+
+        public int AttributeQuoteEnd { get; }
+
+        public int EndInActualDocument { get; }
+
+        public bool IsModified { get; }
+
+        public string OriginalText { get; }
+
+        public string ElementText { get; }
+
+        public string TagName { get; }
+
+        public string AttributeName { get; }
+
+        public int AttributeValueStart => AttributeQuoteStart + 1;
+
+        public int AttributeValueLength => AttributeQuoteEnd - AttributeQuoteStart - 1;
+
+        public int RealDocumentLength => EndInActualDocument - TagStart + 1;
+
+        public void Flatten(out string documentText, out int start, out int end, out int startQuote, out int endQuote, out int realEnd, out bool isHealingRequired, out string healedXml)
+        {
+            documentText = OriginalText;
+            start = TagStart;
+            end = TagEnd;
+            startQuote = AttributeQuoteStart;
+            endQuote = AttributeQuoteEnd;
+            realEnd = EndInActualDocument;
+            isHealingRequired = IsModified;
+            healedXml = ElementText;
+        }
+    }
+}

--- a/src/ProjectFileTools/Helpers/XmlTools.cs
+++ b/src/ProjectFileTools/Helpers/XmlTools.cs
@@ -1,0 +1,190 @@
+﻿using Microsoft.VisualStudio.Text;
+
+namespace ProjectFileTools.Helpers
+{
+    internal static class XmlTools
+    {
+        public static XmlInfo GetXmlInfo(ITextSnapshot snapshot, int pos)
+        {
+            if (pos < 1)
+            {
+                return null;
+            }
+
+            string documentText = snapshot.GetText();
+            return GetXmlInfo(documentText, pos);
+        }
+
+        public static XmlInfo GetXmlInfo(string documentText, int pos)
+        {
+            if (pos < 1)
+            {
+                return null;
+            }
+
+            int start = pos < documentText.Length ? documentText.LastIndexOf('<', pos) : documentText.LastIndexOf('<');
+            int end = pos < documentText.Length ? documentText.IndexOf('>', pos) : -1;
+            int startQuote = documentText.LastIndexOf('"', pos - 1);
+            int endQuote = pos < documentText.Length ? documentText.IndexOf('"', pos) : -1;
+            int realEnd = end;
+            bool isHealed = false;
+
+            if (startQuote > -1 && startQuote < start || end > -1 && endQuote > end)
+            {
+                return null;
+            }
+
+            string fragmentText = null;
+            //If we managed to find a close...
+            if (end > start)
+            {
+                int nextStart = start < documentText.Length - 1 ? documentText.IndexOf('<', start + 1) : -1;
+
+                //If we found another start before the close...
+                //      <PackageReference Include="
+                //  </ItemGroup>
+                if (nextStart > -1 && nextStart < end)
+                {
+                    //Heal
+                    fragmentText = documentText.Substring(start, nextStart - start).Trim();
+                    realEnd = fragmentText.Length + start - 1;
+
+                    switch (fragmentText[fragmentText.Length - 1])
+                    {
+                        case '\"':
+                            if (endQuote > nextStart || endQuote < 0)
+                            {
+                                endQuote = fragmentText.Length + start;
+                                fragmentText += "\"";
+                            }
+                            break;
+                        case '>':
+                            return null;
+                        default:
+                            //If there's a start quote in play, we're just looking at an unclosed attribute value
+                            if (startQuote > start)
+                            {
+                                endQuote = fragmentText.Length + start;
+                                fragmentText += "\"";
+                            }
+                            else
+                            {
+                                return null;
+                            }
+                            break;
+                    }
+
+                    end = fragmentText.Length + 2 + start;
+                    fragmentText += " />";
+                    isHealed = true;
+                }
+                //We didn't find that, so we're "good"... we might have a non-self closed tag though
+                else
+                {
+                    isHealed = false;
+
+                    //Unless of course the closing quote was after the end...
+                    if (endQuote < 0 || endQuote > end)
+                    {
+                        fragmentText = documentText.Substring(start, end - start);
+
+                        if (fragmentText.EndsWith("/"))
+                        {
+                            fragmentText = fragmentText.Substring(0, fragmentText.Length - 1);
+                        }
+
+                        fragmentText = fragmentText.TrimEnd() + "\" />";
+
+                        endQuote = fragmentText.Length - 4 + start;
+                        end = fragmentText.Length - 1 + start;
+                    }
+                    else
+                    {
+                        fragmentText = documentText.Substring(start, end - start + 1);
+                    }
+                }
+            }
+            //If we didn't find a close, if we found an end quote, that's good enough
+            else if (endQuote > start)
+            {
+                realEnd = endQuote;
+                fragmentText = documentText.Substring(start, endQuote - start + 1) + " />";
+                end = fragmentText.Length - 1 + start;
+                isHealed = true;
+            }
+            //If we didn't find an end quote even, if we found an open quote, that might be good enough
+            else if (startQuote > start)
+            {
+                //If we find a close before the cursor that's after the start quote, we're outside of the element
+                if (documentText.LastIndexOf('>', pos - 1) > startQuote)
+                {
+                    return null;
+                }
+
+                //Otherwise, we're presumably just after the start quote (and maybe some text) at the end of the document
+                //  we already know there's no closing quote or end, see if there's another start we can run up to
+                int nextStart = pos < documentText.Length ? documentText.IndexOf('<', pos) : -1;
+
+                //If there isn't, run off to the end of the document
+                if (nextStart < 0)
+                {
+                    fragmentText = documentText.Substring(start, documentText.Length - start).TrimEnd();
+                }
+                else
+                {
+                    fragmentText = documentText.Substring(start, nextStart - start + 1);
+                    fragmentText = fragmentText.Trim();
+                }
+
+                realEnd = start + fragmentText.Length - 1;
+                fragmentText += "\" />";
+                endQuote = fragmentText.Length - 4 + start;
+                end = fragmentText.Length - 1 + start;
+                isHealed = true;
+            }
+            //All we've got to go on is the start, that's not good enough
+            else
+            {
+                return null;
+            }
+
+            string healedXml = fragmentText;
+
+            int indexAfterTagNameEnd = healedXml.FindFirstWhitespaceAtOrAfter(1);
+            string tagName = healedXml.Substring(1, indexAfterTagNameEnd - 1);
+            int equalsIndex = healedXml.LastIndexOf('=', startQuote - start) - 1;
+            int afterAttributeIndex = healedXml.FindFirstNonWhitespaceAtOrBefore(equalsIndex, false);
+            int beforeAttributeIndex = healedXml.FindFirstNonWhitespaceAtOrBefore(afterAttributeIndex, true);
+            string attributeName = healedXml.Substring(beforeAttributeIndex + 1, afterAttributeIndex - beforeAttributeIndex);
+            string orignalText = documentText.Substring(start, realEnd - start + 1);
+
+            return new XmlInfo(orignalText, healedXml, start, end, startQuote, endQuote, isHealed, realEnd, tagName, attributeName);
+        }
+
+        private static int FindFirstWhitespaceAtOrAfter(this string text, int startAt)
+        {
+            for (int i = startAt; i < text.Length; ++i)
+            {
+                if (char.IsWhiteSpace(text[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int FindFirstNonWhitespaceAtOrBefore(this string text, int startAt, bool invert)
+        {
+            for (int i = startAt; i > -1; --i)
+            {
+                if (invert ^ !char.IsWhiteSpace(text[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/ProjectFileTools/ProjectFileTools.csproj
+++ b/src/ProjectFileTools/ProjectFileTools.csproj
@@ -49,6 +49,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Helpers\XmlInfo.cs" />
+    <Compile Include="Helpers\XmlTools.cs" />
     <Page Include="**\*.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Package completion now works in cases where:
* The closing quote is missing
* The self closing tag is present but no closing quote is
* The element is the last one in the document & isn't fully formed

The version attribute is now added automatically if it's not present.

After committing a package name completion, the version attribute's value has the cursor automatically moved into it and intellisense is retriggered