### PR TITLE
Add find all references for getting the list of files covered by a glob

### DIFF
--- a/src/ProjectFileTools.MSBuild/IWorkspace.cs
+++ b/src/ProjectFileTools.MSBuild/IWorkspace.cs
@@ -4,6 +4,10 @@ namespace ProjectFileTools.MSBuild
 {
     public interface IWorkspace
     {
+        List<Definition> GetItems(string fileSpec);
+
+        List<Definition> GetItemProvenance(string fileSpec);
+
         List<Definition> ResolveDefinition(string filePath, string sourceText, int position);
     }
 }

--- a/src/ProjectFileTools/Helpers/XmlInfo.cs
+++ b/src/ProjectFileTools/Helpers/XmlInfo.cs
@@ -57,6 +57,8 @@ namespace ProjectFileTools.Helpers
 
         public int AttributeValueLength => AttributeQuoteEnd - AttributeQuoteStart - 1;
 
+        public string AttributeValue => ElementText.Substring(AttributeValueStart - TagStart, AttributeValueLength);
+
         public int RealDocumentLength => EndInActualDocument - TagStart + 1;
 
         public void Flatten(out string documentText, out int start, out int end, out int startQuote, out int endQuote, out int realEnd, out bool isHealingRequired, out string healedXml)


### PR DESCRIPTION
Fixes QueryStatus for hooking up Go To Definition

Adds getting item provenance as the Go To Definition action on globs

![globeval](https://user-images.githubusercontent.com/1414993/38124495-cf712978-3396-11e8-8fd4-7996b132d9e7.png)
![provenance](https://user-images.githubusercontent.com/1414993/38124497-cf9ee4d0-3396-11e8-8ef5-8b1a7203e44d.png)
