### PR TITLE
Reinforces code against null ref exceptions

### DIFF
--- a/src/ProjectFileTools/Completion/CompletionController.cs
+++ b/src/ProjectFileTools/Completion/CompletionController.cs
@@ -117,7 +117,8 @@ namespace ProjectFileTools.Completion
 
                 _currentSession.Dismissed += (sender, args) =>
                 {
-                    _currentSession.Committed -= HandleCompletionSessionCommit;
+                    if (sender is ICompletionSession session)
+                        session.Committed -= HandleCompletionSessionCommit;
                     _currentSession = null;
                 };
                 _currentSession.Committed += HandleCompletionSessionCommit;
@@ -174,7 +175,8 @@ namespace ProjectFileTools.Completion
 
                 currentSession.Dismissed += (sender, args) =>
                 {
-                    currentSession.Committed -= HandleCompletionSessionCommit;
+                    if (sender is ICompletionSession session)
+                        session.Committed -= HandleCompletionSessionCommit;
                     _currentSession = null;
                 };
                 currentSession.Committed += HandleCompletionSessionCommit;
@@ -234,7 +236,8 @@ namespace ProjectFileTools.Completion
             {
                 currentSession.Dismissed += (sender, args) =>
                 {
-                    currentSession.Committed -= HandleCompletionSessionCommit;
+                    if (sender is ICompletionSession session)
+                        session.Committed -= HandleCompletionSessionCommit;
                     _currentSession = null;
                 };
 


### PR DESCRIPTION
ProjFileTools crashes VS during interactions in .axml files (Xamarin workflow). 

The direct cause of this is that references used in event handlers are stale after the completion commits.

The reason this issue happens in Xamarin is that Xamarin uses async completion API (that I would like to help you onboard!) whose shim completion session may have a different call pattern.