### PR TITLE
Fix installation of Project File Tools on Visual Studio 2019 updates

### DIFF
--- a/src/ProjectFileTools/source.extension.vsixmanifest
+++ b/src/ProjectFileTools/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
         <Tags>project, csproj, vbproj</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27906.1,16.1)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27906.1,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Unlike other VS releases in 2019 updates minor point releases are being used ([src](https://devblogs.microsoft.com/visualstudio/visual-studio-extensions-and-version-ranges-demystified/)). So I changed the range like specified in this [blog post](https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/). This fixes issue #61.