### PR TITLE
Implement NuGet V2 Feed support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ download in the
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery.
 
+## 1.4
+- [x] Implement NuGet V2 Feed support
+
 ## 1.1
 
 - [x] Go To Definition (F12) for MSBuild imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ on the official Visual Studio extension gallery.
 
 ## 1.4
 - [x] Implement NuGet V2 Feed support
+- [x] Change WebRequestFactory to use a static HttpClient to avoid connection socket exhaustion problem
 
 ## 1.1
 

--- a/src/ProjectFileTools.NuGetSearch/Feeds/Web/NuGetV2ServiceFeed.cs
+++ b/src/ProjectFileTools.NuGetSearch/Feeds/Web/NuGetV2ServiceFeed.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
+using ProjectFileTools.NuGetSearch.Contracts;
+using ProjectFileTools.NuGetSearch.IO;
+using ProjectFileTools.NuGetSearch.Search;
+
+namespace ProjectFileTools.NuGetSearch.Feeds.Web
+{
+    public class NuGetV2ServiceFeedFactory : IPackageFeedFactory
+    {
+        private readonly IWebRequestFactory _webRequestFactory;
+
+        public NuGetV2ServiceFeedFactory(IWebRequestFactory webRequestFactory)
+        {
+            _webRequestFactory = webRequestFactory;
+        }
+
+        public bool TryHandle(string feed, out IPackageFeed instance)
+        {
+            if (Uri.TryCreate(feed, UriKind.Absolute, out Uri location) && feed.EndsWith("nuget", StringComparison.OrdinalIgnoreCase))
+            {
+                instance = new NuGetV2ServiceFeed(feed, _webRequestFactory);
+                return true;
+            }
+
+            instance = null;
+            return false;
+        }
+    }
+
+    public class NuGetV2ServiceFeed : IPackageFeed
+    {
+        private readonly string _feed;
+        private readonly FeedKind _kind;
+        private readonly IWebRequestFactory _webRequestFactory;
+
+        public NuGetV2ServiceFeed(string feed, IWebRequestFactory webRequestFactory)
+        {
+            _webRequestFactory = webRequestFactory;
+            _feed = feed;
+            _kind = feed.IndexOf("nuget.org", StringComparison.OrdinalIgnoreCase) > -1 ? FeedKind.NuGet : FeedKind.MyGet;
+        }
+
+        public string DisplayName => $"{_feed} (NuGet v2)";
+
+        private async Task<XDocument> ExecuteAutocompleteServiceQueryAsync(IEnumerable<string> endpoints, Func<string, string> query, CancellationToken cancellationToken)
+        {
+            if (endpoints == null)
+            {
+                return null;
+            }
+
+            for (int i = 0; i < endpoints.Count(); ++i)
+            {
+                string endpoint = endpoints.First();
+
+                try
+                {
+                    string location = query(endpoint);
+                    var xml = await _webRequestFactory.GetStringAsync(location, cancellationToken).ConfigureAwait(false);
+                    return XDocument.Parse(xml);
+                }
+                catch (Exception)
+                { 
+                    //TODO: Possibly log the failure to get the document 
+                }
+            }
+
+            return null;
+        }
+
+        public async Task<IPackageNameSearchResult> GetPackageNamesAsync(string prefix, IPackageQueryConfiguration queryConfiguration, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return PackageNameSearchResult.Failure;
+            }
+
+            IReadOnlyList<string> results = new List<string>();
+            string frameworkQuery = !string.IsNullOrEmpty(queryConfiguration.CompatibiltyTarget) ? $"&targetFramework={queryConfiguration.CompatibiltyTarget}" : "";
+            var serviceEndpoints = new[] { $"{_feed}/Search()" };
+            Func<string, string> queryFunc = x => $"{x}?searchTerm={prefix}{frameworkQuery}&includePrerelease={queryConfiguration.IncludePreRelease}";
+            XDocument document = await ExecuteAutocompleteServiceQueryAsync(serviceEndpoints, queryFunc, cancellationToken).ConfigureAwait(false);
+
+            if (document != null)
+            {
+                try
+                {
+                    results = GetPackageNamesFromNuGetV2CompatibleQueryResult(document);
+                    return new PackageNameSearchResult(results, _kind);
+                }
+                catch
+                {
+                }
+            }
+
+            return PackageNameSearchResult.Failure;
+        }
+
+        public async Task<IPackageInfo> GetPackageInfoAsync(string packageId, string version, IPackageQueryConfiguration queryConfiguration, CancellationToken cancellationToken)
+        {
+            if (packageId == null)
+            {
+                return null;
+            }
+
+            var serviceEndpoints = new[] { $"{_feed}/Packages(Id='{packageId}',Version='{version}')" };
+            Func<string, string> queryFunc = x => $"{x}";
+            XDocument document = await ExecuteAutocompleteServiceQueryAsync(serviceEndpoints, queryFunc, cancellationToken).ConfigureAwait(false);
+
+            if (document != null)
+            {
+                var el = document.Root;
+
+                var id = GetPropertyValue(document, el, "Id");
+                var title = GetPropertyValue(document, el, "Title");
+                var authors = GetPropertyValue(document, el, "Authors");
+                var summary = GetPropertyValue(document, el, "Summary");
+                var description = GetPropertyValue(document, el, "Description");
+                var projectUrl = GetPropertyValue(document, el, "ProjectUrl");
+                var licenseUrl = GetPropertyValue(document, el, "LicenseUrl");
+                var iconUrl = GetPropertyValue(document, el, "IconUrl");
+                var tags = GetPropertyValue(document, el, "Tags");
+                var packageInfo = new PackageInfo(id, version, title, authors, summary, description, licenseUrl, projectUrl, iconUrl, tags, _kind);
+                return packageInfo;
+            }
+
+
+            return null;
+        }
+
+        private static string GetPropertyValue(XDocument document, XElement el, string propertyKey)
+        {
+            return el
+                    .Element(document.Root.GetNamespaceOfPrefix("m") + "properties")
+                    .Element(document.Root.GetNamespaceOfPrefix("d") + propertyKey)
+                    ?.Value;
+        }
+
+        public async Task<IPackageVersionSearchResult> GetPackageVersionsAsync(string id, IPackageQueryConfiguration queryConfiguration, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<string> results = new List<string>();
+            var serviceEndpoints = new[] { $"{_feed}/FindPackagesById()" };
+            Func<string, string> queryFunc = x => $"{x}?id='{id}'";
+            XDocument document = await ExecuteAutocompleteServiceQueryAsync(serviceEndpoints, queryFunc, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                results = GetPackageVersionsFromNuGetV2CompatibleQueryResult(id, document);
+            }
+            catch
+            {
+                return PackageVersionSearchResult.Failure;
+            }
+
+            return new PackageVersionSearchResult(results, _kind);
+        }
+
+        private static IReadOnlyList<string> GetPackageVersionsFromNuGetV2CompatibleQueryResult(string id, XDocument document)
+        {
+            List<string> results = new List<string>();
+
+            if (document != null)
+            {
+                foreach (var el in document.Root.Elements(document.Root.GetDefaultNamespace() + "entry"))
+                {
+                    var pkgId = GetPropertyValue(document, el, "Id");
+
+                    var pkgVersion = GetPropertyValue(document, el, "Version");
+
+                    if (pkgId.Equals(pkgId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        results.Add(pkgVersion);
+                    }
+                }
+            }
+
+            return results.AsReadOnly();
+        }
+
+        private static IReadOnlyList<string> GetPackageNamesFromNuGetV2CompatibleQueryResult(XDocument document)
+        {
+            List<string> results = new List<string>();
+
+            if (document != null)
+            {
+                foreach (var el in document.Root.Elements(document.Root.GetDefaultNamespace() +"entry"))
+                {
+                    var id = GetPropertyValue(document, el, "Id");
+
+                    results.Add(id);
+                }
+            }
+            
+            return results.Distinct().ToList().AsReadOnly();
+        }
+    }
+}

--- a/src/ProjectFileTools.NuGetSearch/Feeds/Web/NuGetV2ServiceFeed.cs
+++ b/src/ProjectFileTools.NuGetSearch/Feeds/Web/NuGetV2ServiceFeed.cs
@@ -84,7 +84,7 @@ namespace ProjectFileTools.NuGetSearch.Feeds.Web
             IReadOnlyList<string> results = new List<string>();
             string frameworkQuery = !string.IsNullOrEmpty(queryConfiguration.CompatibiltyTarget) ? $"&targetFramework={queryConfiguration.CompatibiltyTarget}" : "";
             var serviceEndpoints = new[] { $"{_feed}/Search()" };
-            Func<string, string> queryFunc = x => $"{x}?searchTerm={prefix}{frameworkQuery}&includePrerelease={queryConfiguration.IncludePreRelease}";
+            Func<string, string> queryFunc = x => $"{x}?searchTerm='{prefix}'{frameworkQuery}&includePrerelease={queryConfiguration.IncludePreRelease}";
             XDocument document = await ExecuteAutocompleteServiceQueryAsync(serviceEndpoints, queryFunc, cancellationToken).ConfigureAwait(false);
 
             if (document != null)

--- a/src/ProjectFileTools.NuGetSearch/Feeds/Web/NuGetV2ServiceFeed.cs
+++ b/src/ProjectFileTools.NuGetSearch/Feeds/Web/NuGetV2ServiceFeed.cs
@@ -59,7 +59,7 @@ namespace ProjectFileTools.NuGetSearch.Feeds.Web
             IReadOnlyList<string> results = new List<string>();
             string frameworkQuery = !string.IsNullOrEmpty(queryConfiguration.CompatibiltyTarget) ? $"&targetFramework={queryConfiguration.CompatibiltyTarget}" : "";
             var serviceEndpoint = $"{_feed}/Search()";
-            Func<string, string> queryFunc = x => $"{x}?searchTerm='{prefix}'{frameworkQuery}&includePrerelease={queryConfiguration.IncludePreRelease}";
+            Func<string, string> queryFunc = x => $"{x}?searchTerm='{prefix}'{frameworkQuery}&includePrerelease={queryConfiguration.IncludePreRelease}&semVerLevel=2.0.0";
             XDocument document = await ExecuteAutocompleteServiceQueryAsync(serviceEndpoint, queryFunc, cancellationToken).ConfigureAwait(false);
 
             if (document != null)
@@ -148,7 +148,7 @@ namespace ProjectFileTools.NuGetSearch.Feeds.Web
             return null;
         }
 
-
+            
         private static string GetPropertyValue(XDocument document, XElement el, string propertyKey)
         {
             return el

--- a/src/ProjectFileTools.NuGetSearch/IO/WebRequestFactory.cs
+++ b/src/ProjectFileTools.NuGetSearch/IO/WebRequestFactory.cs
@@ -6,16 +6,14 @@ namespace ProjectFileTools.NuGetSearch.IO
 {
     public class WebRequestFactory : IWebRequestFactory
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
         public async Task<string> GetStringAsync(string endpoint, CancellationToken cancellationToken)
         {
             try
             {
-                using (HttpClient client = new HttpClient())
-                {
-                    HttpResponseMessage responseMessage = await client.GetAsync(endpoint, cancellationToken).ConfigureAwait(false);
-                    responseMessage.EnsureSuccessStatusCode();
-                    return await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-                }
+                HttpResponseMessage responseMessage = await _httpClient.GetAsync(endpoint, cancellationToken).ConfigureAwait(false);
+                responseMessage.EnsureSuccessStatusCode();
+                return await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
             catch
             {

--- a/src/ProjectFileTools/Exports/ExportedNuGetV2ServiceFeedFactory.cs
+++ b/src/ProjectFileTools/Exports/ExportedNuGetV2ServiceFeedFactory.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Utilities;
+using ProjectFileTools.NuGetSearch.Contracts;
+using ProjectFileTools.NuGetSearch.Feeds.Web;
+using ProjectFileTools.NuGetSearch.IO;
+
+namespace ProjectFileTools.Exports
+{
+    [Export(typeof(IPackageFeedFactory))]
+    [Name("Default NuGet v2 Service Feed Factory")]
+    internal class ExportedNuGetV2ServiceFeedFactory : NuGetV2ServiceFeedFactory
+    {
+        [ImportingConstructor]
+        public ExportedNuGetV2ServiceFeedFactory(IWebRequestFactory webRequestFactory)
+            : base(webRequestFactory)
+        {
+        }
+    }
+}

--- a/src/ProjectFileTools/ProjectFileTools.csproj
+++ b/src/ProjectFileTools/ProjectFileTools.csproj
@@ -49,6 +49,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Exports\ExportedNuGetV2ServiceFeedFactory.cs" />
     <Compile Include="Helpers\XmlInfo.cs" />
     <Compile Include="Helpers\XmlTools.cs" />
     <Page Include="**\*.xaml">

--- a/src/ProjectFileTools/source.extension.vsixmanifest
+++ b/src/ProjectFileTools/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
         <Tags>project, csproj, vbproj</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27906.1,16.1)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27906.1,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/test/ProjectFileTools.NuGetSearch.Tests/NuGetV2ServiceFeedTests.cs
+++ b/test/ProjectFileTools.NuGetSearch.Tests/NuGetV2ServiceFeedTests.cs
@@ -39,7 +39,7 @@ namespace ProjectFileTools.NuGetSearch.Tests
                 var webRequestFactory = Mock.Of<IWebRequestFactory>();
 
                 Mock.Get(webRequestFactory)
-                    .Setup(f => f.GetStringAsync("http://localhost/nuget/Search()?searchTerm=Common.Logging&targetFramework=netcoreapp2.0&includePrerelease=False", It.IsAny<CancellationToken>()))
+                    .Setup(f => f.GetStringAsync("http://localhost/nuget/Search()?searchTerm='Common.Logging'&targetFramework=netcoreapp2.0&includePrerelease=False", It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult(GetXmlFromTestFile(testFile)));
 
                 var sut = new NuGetV2ServiceFeed(feed, webRequestFactory);

--- a/test/ProjectFileTools.NuGetSearch.Tests/NuGetV2ServiceFeedTests.cs
+++ b/test/ProjectFileTools.NuGetSearch.Tests/NuGetV2ServiceFeedTests.cs
@@ -1,0 +1,116 @@
+﻿using FluentAssertions;
+using Moq;
+using ProjectFileTools.NuGetSearch.Feeds;
+using ProjectFileTools.NuGetSearch.Feeds.Web;
+using ProjectFileTools.NuGetSearch.IO;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ProjectFileTools.NuGetSearch.Tests
+{
+    /// <summary>
+    /// The tests below only work when signing is disabled.
+    /// When signing enabled, no test will be found as a result of `ProjectFileTools.NuGetSearch` failing to load with signing key validation error
+    /// </summary>
+    public class NuGetV2ServiceFeedTests
+    {
+       
+        public class TheDisplayNameProperty
+        {
+
+            [Theory]
+            [InlineData("http://localhost/nuget")]
+            public void GivenFeed_ReturnDisplayName(string feed)
+            {
+                var webRequestFactory = Mock.Of<IWebRequestFactory>();
+                var sut = new NuGetV2ServiceFeed(feed, webRequestFactory);
+                sut.DisplayName.Should().Be($"{feed} (NuGet v2)");
+            }
+        }
+
+        public class TheGetPackageNamesAsyncMethod
+        {
+            [Theory]
+            [InlineData("http://localhost/nuget", "GetPackageNames.CommonLogging.xml")]
+            public async Task GivenPackagesFound_ReturnListOfIds(string feed, string testFile)
+            {
+                var webRequestFactory = Mock.Of<IWebRequestFactory>();
+
+                Mock.Get(webRequestFactory)
+                    .Setup(f => f.GetStringAsync("http://localhost/nuget/Search()?searchTerm=Common.Logging&targetFramework=netcoreapp2.0&includePrerelease=False", It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(GetXmlFromTestFile(testFile)));
+
+                var sut = new NuGetV2ServiceFeed(feed, webRequestFactory);
+
+                var packageNameResults = await sut.GetPackageNamesAsync("Common.Logging", new PackageQueryConfiguration("netcoreapp2.0", false), new CancellationToken());
+                packageNameResults.Names.Count.Should().Be(5);
+            }
+        }
+
+        public class TheGetPackageVersionsAsyncMethod
+        {
+            [Theory]
+            [InlineData("http://localhost/nuget", "GetPackageVersions.CommonLogging.xml")]
+            public async Task GivenPackagesFound_ReturnListOfVersions(string feed, string testFile)
+            {
+                var webRequestFactory = Mock.Of<IWebRequestFactory>();
+
+                Mock.Get(webRequestFactory)
+                    .Setup(f => f.GetStringAsync("http://localhost/nuget/FindPackagesById()?id='Acme.Common.Logging.AspNetCore'", It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(GetXmlFromTestFile(testFile)));
+
+                var sut = new NuGetV2ServiceFeed(feed, webRequestFactory);
+
+                var packageNameResults = await sut.GetPackageVersionsAsync("Acme.Common.Logging.AspNetCore", new PackageQueryConfiguration("netcoreapp2.0", false), new CancellationToken());
+                packageNameResults.Versions.Count.Should().Be(8);
+                Assert.Collection(packageNameResults.Versions,
+                    v => v.Should().Be("1.6.0.5"),
+                    v => v.Should().Be("1.6.1"),
+                    v => v.Should().Be("1.6.2"),
+                    v => v.Should().Be("1.7.0"),
+                    v => v.Should().Be("1.7.1"),
+                    v => v.Should().Be("1.8.0"),
+                    v => v.Should().Be("1.9.0"),
+                    v => v.Should().Be("1.9.1"));
+            }
+        }
+
+        public class TheGetPackageInfoAsyncMethod
+        {
+            [Theory]
+            [InlineData("http://localhost/nuget", "GetPackageInfo.CommonLogging.xml")]
+            public async Task GivenPackageFound_ReturnPackageInfo(string feed, string testFile)
+            {
+                var webRequestFactory = Mock.Of<IWebRequestFactory>();
+
+                Mock.Get(webRequestFactory)
+                    .Setup(f => f.GetStringAsync("http://localhost/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')", It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(GetXmlFromTestFile(testFile)));
+
+                var sut = new NuGetV2ServiceFeed(feed, webRequestFactory);
+
+                var pkgInfo = await sut.GetPackageInfoAsync("Acme.Common.Logging.AspNetCore", "1.8.0", new PackageQueryConfiguration("netcoreapp2.0", false), new CancellationToken());
+
+                pkgInfo.Id.Should().Be("Acme.Common.Logging.AspNetCore"); 
+                pkgInfo.Title.Should().Be("Common Logging AspNetCore");
+                pkgInfo.Summary.Should().BeNullOrEmpty();
+                pkgInfo.Description.Should().Be("Common Logging integration within Aspnet core services");
+                pkgInfo.Authors.Should().Be("Patrick Assuied");
+                pkgInfo.Version.Should().Be("1.8.0");
+                pkgInfo.ProjectUrl.Should().Be("https://bitbucket.acme.com/projects/Acme/repos/Acme-common-logging");
+                pkgInfo.LicenseUrl.Should().BeNullOrEmpty();
+                pkgInfo.Tags.Should().Be(" common logging aspnetcore ");
+
+
+            }
+        }
+
+        public static string GetXmlFromTestFile(string filename)
+        {
+            string path = Path.Combine(Directory.GetCurrentDirectory(), $"../../test/ProjectFileTools.NuGetSearch.Tests/TestFiles/{filename}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/test/ProjectFileTools.NuGetSearch.Tests/NuGetV2ServiceFeedTests.cs
+++ b/test/ProjectFileTools.NuGetSearch.Tests/NuGetV2ServiceFeedTests.cs
@@ -39,7 +39,7 @@ namespace ProjectFileTools.NuGetSearch.Tests
                 var webRequestFactory = Mock.Of<IWebRequestFactory>();
 
                 Mock.Get(webRequestFactory)
-                    .Setup(f => f.GetStringAsync("http://localhost/nuget/Search()?searchTerm='Common.Logging'&targetFramework=netcoreapp2.0&includePrerelease=False", It.IsAny<CancellationToken>()))
+                    .Setup(f => f.GetStringAsync("http://localhost/nuget/Search()?searchTerm='Common.Logging'&targetFramework=netcoreapp2.0&includePrerelease=False&semVerLevel=2.0.0", It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult(GetXmlFromTestFile(testFile)));
 
                 var sut = new NuGetV2ServiceFeed(feed, webRequestFactory);

--- a/test/ProjectFileTools.NuGetSearch.Tests/ProjectFileTools.NuGetSearch.Tests.csproj
+++ b/test/ProjectFileTools.NuGetSearch.Tests/ProjectFileTools.NuGetSearch.Tests.csproj
@@ -5,11 +5,12 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.6-preview" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.0.7-preview" />
-    <PackageReference Include="NuGet.Frameworks" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="FluentAssertions" Version="5.7.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="4.6.4" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ProjectFileTools.NuGetSearch.Tests/TestFiles/GetPackageInfo.CommonLogging.xml
+++ b/test/ProjectFileTools.NuGetSearch.Tests/TestFiles/GetPackageInfo.CommonLogging.xml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<entry xml:base="http://localhost/Nuget/nuget" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+  <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')</id>
+  <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+  <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')" />
+  <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')" />
+  <title type="text">Acme.Common.Logging.AspNetCore</title>
+  <published>2018-11-21T17:31:07Z</published>
+  <updated>2018-11-21T17:31:07Z</updated>
+  <author>
+    <name>Patrick Assuied</name>
+  </author>
+  <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')/Download" />
+  <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')/Download" />
+  <m:properties>
+    <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+    <d:Version>1.8.0</d:Version>
+    <d:NormalizedVersion>1.8.0</d:NormalizedVersion>
+    <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+    <d:Title>Common Logging AspNetCore</d:Title>
+    <d:Authors>Patrick Assuied</d:Authors>
+    <d:Owners>Patrick Assuied</d:Owners>
+    <d:IconUrl m:null="true" />
+    <d:LicenseUrl m:null="true" />
+    <d:ProjectUrl>https://bitbucket.acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+    <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+    <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+    <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+    <d:Description>Common Logging integration within Aspnet core services</d:Description>
+    <d:Summary m:null="true" />
+    <d:ReleaseNotes>## Available in CHANGELOG.md</d:ReleaseNotes>
+    <d:Published m:type="Edm.DateTime">2018-11-21T17:31:07.1944763Z</d:Published>
+    <d:LastUpdated m:type="Edm.DateTime">2018-11-21T17:31:07.1944763Z</d:LastUpdated>
+    <d:Dependencies>Acme.Common.Logging.Configuration:1.8.0:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.3:netcoreapp2.0|NLog.Web.AspNetCore:4.5.4:netcoreapp2.0|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.0|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.0|Acme.Common.Logging.Configuration:1.8.0:netcoreapp2.1|Microsoft.AspNetCore.Diagnostics:2.1.1:netcoreapp2.1|NLog.Web.AspNetCore:4.5.4:netcoreapp2.1|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.1|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.1</d:Dependencies>
+    <d:PackageHash>KP5xJayLLtWJx59wz6rSHW8tvxNY4xp/3eCsqG2QF7wINphpXs+0k2rKLigMWq/6geWptbdXXjJdZXYJUG0EUQ==</d:PackageHash>
+    <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+    <d:PackageSize m:type="Edm.Int64">22002</d:PackageSize>
+    <d:Copyright>Copyright 2016-2018</d:Copyright>
+    <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+    <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+    <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+    <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+    <d:MinClientVersion m:null="true" />
+    <d:Language m:null="true" />
+  </m:properties>
+</entry>

--- a/test/ProjectFileTools.NuGetSearch.Tests/TestFiles/GetPackageNames.CommonLogging.xml
+++ b/test/ProjectFileTools.NuGetSearch.Tests/TestFiles/GetPackageNames.CommonLogging.xml
@@ -1,0 +1,753 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<feed xml:base="http://localhost/Nuget/nuget" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+  <id>http://schemas.datacontract.org/2004/07/</id>
+  <title />
+  <updated>2019-07-07T04:48:53Z</updated>
+  <link rel="self" href="http://localhost/Nuget/nuget/Packages" />
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-04-09T19:12:53Z</published>
+    <updated>2018-04-09T19:12:53Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.6.0.5</d:Version>
+      <d:NormalizedVersion>1.6.0.5</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>
+        ## 1.6.0
+        - Support for .NET core
+      </d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-04-09T19:12:53.6418356Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-04-09T19:12:53.6418356Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.6.0.5:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.2:netcoreapp2.0|NLog.Web.AspNetCore:4.5.1:netcoreapp2.0</d:Dependencies>
+      <d:PackageHash>zclx15xLnnUxm63+IqBWUNCYWAYcHvumBD1CbsXuSpdame0fHPcfv9FlMRodIOHUF9q/yXqkGo/AQTRlMAa88Q==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11395</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-05-04T21:45:54Z</published>
+    <updated>2018-05-04T21:45:54Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.6.1</d:Version>
+      <d:NormalizedVersion>1.6.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>
+        ## 1.6.0
+        - Support for .NET core
+      </d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-05-04T21:45:54.0222438Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-05-04T21:45:54.0222438Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.6.1:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.2:netcoreapp2.0|NLog.Web.AspNetCore:4.5.1:netcoreapp2.0</d:Dependencies>
+      <d:PackageHash>7uBobOiTDhyz6s4P1Fnzgh1PokLYXU7G5E7nHDIpeCoj1B/f/augtWBBcqpuxv+hyDnGsVtyOxxPqso1Jhk1yw==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11399</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.2.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.2.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.2.0')" />
+    <title type="text">Acme.Common.Logging.Configuration</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.2.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.2.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.Configuration</d:Id>
+      <d:Version>1.1.2.0</d:Version>
+      <d:NormalizedVersion>1.1.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging Configuration</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://wiki.Acmeondemand.com/display/PLAT/Acme.Common.Logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging Configuration</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.6754695Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.6754695Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3</d:Dependencies>
+      <d:PackageHash>Cu8qd2sESppuG4hEc3Etlum0S82vhTmDDaLqKHwMfGWuz57sGZkiQyARLEvIDL96eAb4szOslpAYxAhUApuapQ==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">16428</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging configuration </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.0')" />
+    <title type="text">Acme.Common.Logging.Configuration</title>
+    <published>2016-12-12T18:26:29Z</published>
+    <updated>2016-12-12T18:26:29Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.Configuration</d:Id>
+      <d:Version>1.1.3.0</d:Version>
+      <d:NormalizedVersion>1.1.3</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging Configuration</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://wiki.Acmeondemand.com/display/PLAT/Acme.Common.Logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging Configuration</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-12-12T18:26:29.8353212Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-12-12T18:26:29.8353212Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3</d:Dependencies>
+      <d:PackageHash>+Jtb8P8swXBxC8HBqViEyp/0N3+fwoMCPbcTWHeUPOnA93/5P7EopkShQ0XudRK2cMa1LiZf/9AW7HFkNstpqg==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">17319</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging configuration </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.2')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.2')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.2')" />
+    <title type="text">Acme.Common.Logging.Configuration</title>
+    <published>2016-12-29T06:29:44Z</published>
+    <updated>2016-12-29T06:29:44Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.2')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Configuration',Version='1.1.3.2')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.Configuration</d:Id>
+      <d:Version>1.1.3.2</d:Version>
+      <d:NormalizedVersion>1.1.3.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging Configuration</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://wiki.Acmeondemand.com/display/PLAT/Acme.Common.Logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging Configuration</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-12-29T06:29:44.4691432Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-12-29T06:29:44.4701478Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Acme.Configuration:1.0.1.0|Microsoft.AspNet.WebApi.Core:5.2.3</d:Dependencies>
+      <d:PackageHash>N0r+Kg3T294d7uvAP5THOTZcPpuGD30GEev1HGuWXj5eqGH+APRFGvMppfOvyYTcjJfh8HJM8t2hvfXEnJbe8w==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">38607</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging configuration </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.0.2')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.0.2')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.0.2')" />
+    <title type="text">Acme.Common.Logging.Context.Autofac</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.0.2')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.0.2')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.Context.Autofac</d:Id>
+      <d:Version>1.0.0.2</d:Version>
+      <d:NormalizedVersion>1.0.0.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging Platform Context Autofac integration</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration with Platform Context using Autofac</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.6874701Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.6874701Z</d:LastUpdated>
+      <d:Dependencies>Autofac:3.5.2|Common.Logging.NLog41:3.3.1|Acme.Platform.Context.Serialization:1.0.3.0|Acme.Common.Logging.Configuration:1.0.0.2</d:Dependencies>
+      <d:PackageHash>xBSkrpuRVaN4VE6jG1bzrJduetp/ErZm0M5/jEdoAIERLdwN4coAJw2AC5YITxgYUFiVea2RnIBfHk17Qjs6AA==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">9482</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging platform context autofac </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.1.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.1.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.1.0')" />
+    <title type="text">Acme.Common.Logging.Context.Autofac</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.1.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.1.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.Context.Autofac</d:Id>
+      <d:Version>1.0.1.0</d:Version>
+      <d:NormalizedVersion>1.0.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging Platform Context Autofac integration</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration with Platform Context using Autofac</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.6984711Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.6984711Z</d:LastUpdated>
+      <d:Dependencies>Autofac:3.5.2|Common.Logging.NLog41:3.3.1|Acme.Platform.Context.Serialization:1.0.3.0|Acme.Common.Logging.Configuration:1.0.1.0</d:Dependencies>
+      <d:PackageHash>Q2UiaZF1NLAiRA/pBDZmjock5Rmf1dnE0FkLft8T+/Vkkp1GczNTOYLy99xOJ4XDnk3/oHPYK97N4vfJXA3i2g==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">10537</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging platform context autofac </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.2.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.2.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.2.0')" />
+    <title type="text">Acme.Common.Logging.Context.Autofac</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.2.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.Context.Autofac',Version='1.0.2.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.Context.Autofac</d:Id>
+      <d:Version>1.0.2.0</d:Version>
+      <d:NormalizedVersion>1.0.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging Platform Context Autofac integration</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration with Platform Context using Autofac</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.7144706Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.7154707Z</d:LastUpdated>
+      <d:Dependencies>Autofac:3.5.2|Common.Logging.NLog41:3.3.1|Acme.Platform.Context.Serialization:1.0.3.0|Acme.Common.Logging.Configuration:1.0.2.0</d:Dependencies>
+      <d:PackageHash>7Y/XPZFOSTXFciSKUZfhVGPm/Y6of8+yUVdOLGBRBvUd5dSvbwlhHc8tuMNR/HKczTdeYLtrBalUezv06kyzAQ==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">10540</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging platform context autofac </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.0')" />
+    <title type="text">Acme.Common.Logging.NLog</title>
+    <published>2018-04-09T19:13:01Z</published>
+    <updated>2018-04-09T19:13:01Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.NLog</d:Id>
+      <d:Version>4.5.0</d:Version>
+      <d:NormalizedVersion>4.5.0</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging NLog integration for .NET Framework and .NET Standard</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging NLog Integration for Acme for .NET Framework and .NET Standard. Port of Common.Logging.NLog until proper .NET standard support is added</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>
+        ## 4.5.0
+        - Integration with NLog 4.5
+      </d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-04-09T19:13:01.2458675Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-04-09T19:13:01.2468683Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging:[3.4.1, 4.0.0):net452|NLog:4.5.2:net452|Common.Logging:[3.4.1, 4.0.0):netstandard2.0|NLog:4.5.2:netstandard2.0</d:Dependencies>
+      <d:PackageHash>eMynRZ/yRL/I//UEC9Rhp/YE4pOVekFIPH9r39lYuwS0VTlDjKhRH7zyk+A6jhiRRGTQiNORaXaR8NepTix7fg==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">29293</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging configuration nlog </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.1')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.1')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.1')" />
+    <title type="text">Acme.Common.Logging.NLog</title>
+    <published>2018-06-30T18:10:12Z</published>
+    <updated>2018-06-30T18:10:12Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.1')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.1')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.NLog</d:Id>
+      <d:Version>4.5.1</d:Version>
+      <d:NormalizedVersion>4.5.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging NLog integration for .NET Framework and .NET Standard</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging NLog Integration for Acme for .NET Framework and .NET Standard. Port of Common.Logging.NLog until proper .NET standard support is added</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2018-06-30T18:10:12.0216293Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-06-30T18:10:12.0216293Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging:[3.4.1, 4.0.0):net452|NLog:4.5.6:net452|Common.Logging:[3.4.1, 4.0.0):netstandard2.0|NLog:4.5.6:netstandard2.0</d:Dependencies>
+      <d:PackageHash>P7uWjyK1uH48ftn9oI8pSFxfU6e0yzsPDOswYay6wk+q5XTh2mMUjKdNWPy7kee2PrD+8aBLjogQtsEQ8To3Sg==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">29268</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging configuration nlog </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.2')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.2')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.2')" />
+    <title type="text">Acme.Common.Logging.NLog</title>
+    <published>2018-10-25T00:56:28Z</published>
+    <updated>2018-10-25T00:56:28Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.2')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.NLog',Version='4.5.2')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.NLog</d:Id>
+      <d:Version>4.5.2</d:Version>
+      <d:NormalizedVersion>4.5.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging NLog integration for .NET Framework and .NET Standard</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging NLog Integration for Acme for .NET Framework and .NET Standard. Port of Common.Logging.NLog until proper .NET standard support is added</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2018-10-25T00:56:28.0828448Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-10-25T00:56:28.0838453Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging:[3.4.1, 4.0.0):net452|NLog:4.5.6:net452|SourceLink.Copy.PdbFiles:2.8.3:net452|SourceLink.Create.CommandLine:2.8.3:net452|Common.Logging:[3.4.1, 4.0.0):netstandard2.0|NLog:4.5.6:netstandard2.0|SourceLink.Copy.PdbFiles:2.8.3:netstandard2.0|SourceLink.Create.CommandLine:2.8.3:netstandard2.0</d:Dependencies>
+      <d:PackageHash>zcl4j9wMhszI5WmrqxKYJ43as6ZXxfsK+BNmGCm4A60xMH/t6IFVecOBVTUeBnsDx9tJdQGskFzJuSJUU8E9NA==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">29768</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging configuration nlog </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.0.2')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.0.2')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.0.2')" />
+    <title type="text">Acme.Common.Logging.WebApi</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.0.2')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.0.2')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.WebApi</d:Id>
+      <d:Version>1.0.0.2</d:Version>
+      <d:NormalizedVersion>1.0.0.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging WebApi</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Web API Client</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.8324708Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.8324708Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3|Microsoft.Owin:3.0.1|Acme.Common.Logging.Configuration:1.0.0.2</d:Dependencies>
+      <d:PackageHash>RSZgxyO1i61wl3ZFraJotbWHZ+5LLo/CMeo78inmxW+bKo6EqKZIJq4oLW9g4ucPMngjzy6TPTb7mFcwrEXxuw==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">10576</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> configuration contracts </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.1.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.1.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.1.0')" />
+    <title type="text">Acme.Common.Logging.WebApi</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.1.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.1.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.WebApi</d:Id>
+      <d:Version>1.0.1.0</d:Version>
+      <d:NormalizedVersion>1.0.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging WebApi</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Web API Client</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.8425001Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.8425001Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3|Microsoft.Owin:3.0.1|Acme.Common.Logging.Configuration:1.0.1.0</d:Dependencies>
+      <d:PackageHash>0T7Nc9XQvY41Hjhs37kjavEuco0sCBrQP8hNIMVEvkAdnajMjLWueJNKGzRKaUpzTzyFCWfx5/ON4QJAolBHzg==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11047</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> configuration contracts </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.2.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.2.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.2.0')" />
+    <title type="text">Acme.Common.Logging.WebApi</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.2.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.2.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.WebApi</d:Id>
+      <d:Version>1.0.2.0</d:Version>
+      <d:NormalizedVersion>1.0.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging WebApi</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Web API Client</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.8514712Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.8514712Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3|Microsoft.Owin:3.0.1|Acme.Common.Logging.Configuration:1.0.2.0</d:Dependencies>
+      <d:PackageHash>1NXCMeB/UpKQuFKoilR2bIzYuovOQjaB/der3AgkcO5zbLo/bknGt61Cz/CLztUksOG95A9fO1zegI3NtlTmcA==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11095</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> configuration contracts </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.0')" />
+    <title type="text">Acme.Common.Logging.WebApi</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.WebApi</d:Id>
+      <d:Version>1.0.3.0</d:Version>
+      <d:NormalizedVersion>1.0.3</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging WebApi</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl m:null="true" />
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Web API Client</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.8634725Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.8634725Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3|Microsoft.Owin:3.0.1|Acme.Common.Logging.Configuration:1.0.3.0</d:Dependencies>
+      <d:PackageHash>X9qk+cNFTpaeyM8SewBHHhbTkZPTsue5JmFIzHXvnwM3UgDWCx3wwa1Q83ALzYdJkwuKKPQMWKmGwdsGcUvarw==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11107</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> configuration contracts </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.1')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.1')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.1')" />
+    <title type="text">Acme.Common.Logging.WebApi</title>
+    <published>2016-11-16T04:09:55Z</published>
+    <updated>2016-11-16T04:09:55Z</updated>
+    <author>
+      <name>Acme OnDemand, Inc.</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.1')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.WebApi',Version='1.0.3.1')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.WebApi</d:Id>
+      <d:Version>1.0.3.1</d:Version>
+      <d:NormalizedVersion>1.0.3.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Acme Common Logging WebApi</d:Title>
+      <d:Authors>Acme OnDemand, Inc.</d:Authors>
+      <d:Owners>Acme OnDemand, Inc.</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://wiki.Acmeondemand.com/display/PLAT/Acme.Common.Logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Web API Client</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:Published m:type="Edm.DateTime">2016-11-16T04:09:55.8715191Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2016-11-16T04:09:55.8715191Z</d:LastUpdated>
+      <d:Dependencies>Common.Logging.NLog41:3.3.1|Microsoft.AspNet.WebApi.Core:5.2.3|Microsoft.Owin:3.0.1|Acme.Common.Logging.Configuration:1.0.3.1</d:Dependencies>
+      <d:PackageHash>cKlVcH53vwWV9B2Z71b8BwAcpFEKdA/MSTx7YhLBl71cLJeCu7ODmlDqhWzYLtthZheimN5pv6g1LWfRoiinrA==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11125</d:PackageSize>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Tags xml:space="preserve"> configuration contracts </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <link rel="next" href="http://localhost/Nuget/nuget/Search()?searchTerm='Common.Logging'&amp;targetFramework=netcoreapp2.0&amp;includePreRelease=false&amp;$skip=100" />
+</feed>

--- a/test/ProjectFileTools.NuGetSearch.Tests/TestFiles/GetPackageVersions.CommonLogging.xml
+++ b/test/ProjectFileTools.NuGetSearch.Tests/TestFiles/GetPackageVersions.CommonLogging.xml
@@ -1,0 +1,384 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<feed xml:base="http://localhost/Nuget/nuget" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+  <id>http://schemas.datacontract.org/2004/07/</id>
+  <title />
+  <updated>2019-07-07T01:17:34Z</updated>
+  <link rel="self" href="http://localhost/Nuget/nuget/Packages" />
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-04-09T19:12:53Z</published>
+    <updated>2018-04-09T19:12:53Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.0.5')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.6.0.5</d:Version>
+      <d:NormalizedVersion>1.6.0.5</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>
+        ## 1.6.0
+        - Support for .NET core
+      </d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-04-09T19:12:53.6418356Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-04-09T19:12:53.6418356Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.6.0.5:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.2:netcoreapp2.0|NLog.Web.AspNetCore:4.5.1:netcoreapp2.0</d:Dependencies>
+      <d:PackageHash>zclx15xLnnUxm63+IqBWUNCYWAYcHvumBD1CbsXuSpdame0fHPcfv9FlMRodIOHUF9q/yXqkGo/AQTRlMAa88Q==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11395</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-05-04T21:45:54Z</published>
+    <updated>2018-05-04T21:45:54Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.1')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.6.1</d:Version>
+      <d:NormalizedVersion>1.6.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>
+        ## 1.6.0
+        - Support for .NET core
+      </d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-05-04T21:45:54.0222438Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-05-04T21:45:54.0222438Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.6.1:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.2:netcoreapp2.0|NLog.Web.AspNetCore:4.5.1:netcoreapp2.0</d:Dependencies>
+      <d:PackageHash>7uBobOiTDhyz6s4P1Fnzgh1PokLYXU7G5E7nHDIpeCoj1B/f/augtWBBcqpuxv+hyDnGsVtyOxxPqso1Jhk1yw==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11399</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.2')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.2')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.2')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-05-08T01:00:16Z</published>
+    <updated>2018-05-08T01:00:16Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.2')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.6.2')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.6.2</d:Version>
+      <d:NormalizedVersion>1.6.2</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>
+        ## 1.6.0
+        - Support for .NET core
+      </d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-05-08T01:00:16.2897639Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-05-08T01:00:16.2897639Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.6.2:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.2:netcoreapp2.0|NLog.Web.AspNetCore:4.5.1:netcoreapp2.0</d:Dependencies>
+      <d:PackageHash>5ReG+O25Ok1PxC7FXqbubma1UL3PJx7z8YmsThXUGhOih+2IP3k5fjtQo1pOHuTGc5UjOomhOKaeWEIbUXfshA==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11399</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.0')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-06-30T18:10:04Z</published>
+    <updated>2018-06-30T18:10:04Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.7.0</d:Version>
+      <d:NormalizedVersion>1.7.0</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>## Available in CHANGELOG.md</d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-06-30T18:10:04.5956766Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-06-30T18:10:04.5956766Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.7.0:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.2:netcoreapp2.0|NLog.Web.AspNetCore:4.5.4:netcoreapp2.0</d:Dependencies>
+      <d:PackageHash>GF3yaZUYgqCqTLtBxsVzhthbQxBMWj9wWUOgyqcLuty+YmTaIGGToTPiP7T15oQoV9ti7QTYvKoQGJaJEA1TLg==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">11404</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.1')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.1')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.1')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-10-25T00:56:19Z</published>
+    <updated>2018-10-25T00:56:19Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.1')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.7.1')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.7.1</d:Version>
+      <d:NormalizedVersion>1.7.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>## Available in CHANGELOG.md</d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-10-25T00:56:19.9908454Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-10-25T00:56:19.9908454Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.7.1:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.3:netcoreapp2.0|NLog.Web.AspNetCore:4.5.4:netcoreapp2.0|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.0|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.0|Acme.Common.Logging.Configuration:1.7.1:netcoreapp2.1|Microsoft.AspNetCore.Diagnostics:2.1.1:netcoreapp2.1|NLog.Web.AspNetCore:4.5.4:netcoreapp2.1|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.1|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.1</d:Dependencies>
+      <d:PackageHash>E2a85BBdwDwqda2OdKClf/8g28csDkeffMPpe/36IFLZwvOspZUMXCb/cQOk5X3EVlls5nHgA1OKEvud1Spz0g==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">21295</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2018-11-21T17:31:07Z</published>
+    <updated>2018-11-21T17:31:07Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.8.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.8.0</d:Version>
+      <d:NormalizedVersion>1.8.0</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>## Available in CHANGELOG.md</d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2018-11-21T17:31:07.1944763Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2018-11-21T17:31:07.1944763Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.8.0:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.3:netcoreapp2.0|NLog.Web.AspNetCore:4.5.4:netcoreapp2.0|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.0|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.0|Acme.Common.Logging.Configuration:1.8.0:netcoreapp2.1|Microsoft.AspNetCore.Diagnostics:2.1.1:netcoreapp2.1|NLog.Web.AspNetCore:4.5.4:netcoreapp2.1|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.1|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.1</d:Dependencies>
+      <d:PackageHash>KP5xJayLLtWJx59wz6rSHW8tvxNY4xp/3eCsqG2QF7wINphpXs+0k2rKLigMWq/6geWptbdXXjJdZXYJUG0EUQ==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">22002</d:PackageSize>
+      <d:Copyright>Copyright 2016-2018</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.0')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.0')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.0')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2019-06-19T00:57:53Z</published>
+    <updated>2019-06-19T00:57:53Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.0')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.0')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.9.0</d:Version>
+      <d:NormalizedVersion>1.9.0</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>## Available in CHANGELOG.md</d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2019-06-19T00:57:53.7070732Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2019-06-19T00:57:53.7080737Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.9.0:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.3:netcoreapp2.0|NLog.Web.AspNetCore:4.5.4:netcoreapp2.0|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.0|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.0|Acme.Common.Logging.Configuration:1.9.0:netcoreapp2.1|Microsoft.AspNetCore.Diagnostics:2.1.1:netcoreapp2.1|NLog.Web.AspNetCore:4.5.4:netcoreapp2.1|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.1|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.1</d:Dependencies>
+      <d:PackageHash>tjgU5FxQZnzaW8oi3MIAPd0Oua7st8fsv1rtKmy3DipZMAZX8tYCrz/W94fq99CgQTD3BN8z6M6174645ZtIHg==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">22007</d:PackageSize>
+      <d:Copyright>Copyright 2016-2019</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+  <entry>
+    <id>http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.1')</id>
+    <category term="NuGet.Server.Core.DataServices.ODataPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.1')" />
+    <link rel="self" href="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.1')" />
+    <title type="text">Acme.Common.Logging.AspNetCore</title>
+    <published>2019-06-20T23:33:38Z</published>
+    <updated>2019-06-20T23:33:38Z</updated>
+    <author>
+      <name>Patrick Assuied</name>
+    </author>
+    <m:action metadata="http://localhost/Nuget/nuget/$metadata#Container.Download" title="Download" target="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.1')/Download" />
+    <content type="application/zip" src="http://localhost/Nuget/nuget/Packages(Id='Acme.Common.Logging.AspNetCore',Version='1.9.1')/Download" />
+    <m:properties>
+      <d:Id>Acme.Common.Logging.AspNetCore</d:Id>
+      <d:Version>1.9.1</d:Version>
+      <d:NormalizedVersion>1.9.1</d:NormalizedVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Title>Common Logging AspNetCore</d:Title>
+      <d:Authors>Patrick Assuied</d:Authors>
+      <d:Owners>Patrick Assuied</d:Owners>
+      <d:IconUrl m:null="true" />
+      <d:LicenseUrl m:null="true" />
+      <d:ProjectUrl>https://bitbucket.Acme.com/projects/Acme/repos/Acme-common-logging</d:ProjectUrl>
+      <d:DownloadCount m:type="Edm.Int32">-1</d:DownloadCount>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:DevelopmentDependency m:type="Edm.Boolean">false</d:DevelopmentDependency>
+      <d:Description>Common Logging integration within Aspnet core services</d:Description>
+      <d:Summary m:null="true" />
+      <d:ReleaseNotes>## Available in CHANGELOG.md</d:ReleaseNotes>
+      <d:Published m:type="Edm.DateTime">2019-06-20T23:33:38.3885724Z</d:Published>
+      <d:LastUpdated m:type="Edm.DateTime">2019-06-20T23:33:38.3885724Z</d:LastUpdated>
+      <d:Dependencies>Acme.Common.Logging.Configuration:1.9.1:netcoreapp2.0|Microsoft.AspNetCore.Diagnostics:2.0.3:netcoreapp2.0|NLog.Web.AspNetCore:4.5.4:netcoreapp2.0|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.0|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.0|Acme.Common.Logging.Configuration:1.9.1:netcoreapp2.1|Microsoft.AspNetCore.Diagnostics:2.1.1:netcoreapp2.1|NLog.Web.AspNetCore:4.5.4:netcoreapp2.1|SourceLink.Copy.PdbFiles:2.8.3:netcoreapp2.1|SourceLink.Create.CommandLine:2.8.3:netcoreapp2.1</d:Dependencies>
+      <d:PackageHash>yBIXe3PCTRziev9L+AzWKPszTzv7RGhzxmPs6HWqFfQJUNo/WaAE4ORim7dhiFpjluD0knZV9/dLYKl94n3N5A==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">22013</d:PackageSize>
+      <d:Copyright>Copyright 2016-2019</d:Copyright>
+      <d:Tags xml:space="preserve"> common logging aspnetcore </d:Tags>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+      <d:VersionDownloadCount m:type="Edm.Int32">-1</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true" />
+      <d:Language m:null="true" />
+    </m:properties>
+  </entry>
+</feed>

--- a/test/ProjectFileTools.NuGetSearch.Tests/UnitTest1.cs
+++ b/test/ProjectFileTools.NuGetSearch.Tests/UnitTest1.cs
@@ -6,13 +6,13 @@ using ProjectFileTools.NuGetSearch.Contracts;
 using ProjectFileTools.NuGetSearch.Feeds;
 using ProjectFileTools.NuGetSearch.Feeds.Disk;
 using ProjectFileTools.NuGetSearch.IO;
+using Xunit;
 
 namespace PackageFeedManagerTests
 {
-    // [TestClass]
     public class UnitTest1
     {
-        // [TestMethod]
+        [Fact(Skip="Just for testing locally")]
         public void TestMethod1()
         {
             //IFileSystem fileSystem = new MockFileSystem();

--- a/test/ProjectFileTools.NuGetSearch.Tests/UnitTest1.cs
+++ b/test/ProjectFileTools.NuGetSearch.Tests/UnitTest1.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+// using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet.Frameworks;
 using ProjectFileTools.NuGetSearch.Contracts;
 using ProjectFileTools.NuGetSearch.Feeds;
@@ -9,10 +9,10 @@ using ProjectFileTools.NuGetSearch.IO;
 
 namespace PackageFeedManagerTests
 {
-    [TestClass]
+    // [TestClass]
     public class UnitTest1
     {
-        [TestMethod]
+        // [TestMethod]
         public void TestMethod1()
         {
             //IFileSystem fileSystem = new MockFileSystem();


### PR DESCRIPTION
Implement NuGet V2 Feed support.
- Added some unit tests. These cannot be run when signing is on at the moment.
- Needs way to up version