### PR TITLE
Build with VS2019

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -32,12 +32,12 @@ if /I "%1" == "/trx-test-results" set VSTestAdditionalArguments=/logger:trx&&shi
 call :Usage && exit /b 1
 :DoneParsing
 
-if not exist "%VS150COMNTOOLS%" (
-  echo To build this repository, this script needs to be run from a Visual Studio 2017 RC developer command prompt.
+if not exist "%VS160COMNTOOLS%" (
+  echo To build this repository, this script needs to be run from a Visual Studio 2019 developer command prompt.
   echo.
   echo If Visual Studio is not installed, visit this page to download:
   echo.
-  echo https://www.visualstudio.com/vs/visual-studio-2017-rc/
+  echo https://www.visualstudio.com/
   exit /b 1
 )
 


### PR DESCRIPTION
Make a minimal change to enable building with VS 2019 instead of VS 2017.
Note that 2019 is now *required*.