### PR TITLE
Fix the path to MSBuild

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -113,7 +113,7 @@ if "%NuGetHome%" == "" (
 )
 set SignTool="%NuGetHome%\roslyntools.signtool\1.1.0-beta3.21260.1\tools\SignTool.exe"
 
-%SignTool% -config "%Root%build\Signing\SignToolConfig.json" -msbuildPath "%VS160COMNTOOLS%..\..\MSBuild\16.0\Bin\msbuild.exe" "%Root%bin\%BuildConfiguration%"
+%SignTool% -config "%Root%build\Signing\SignToolConfig.json" -msbuildPath "%VS160COMNTOOLS%..\..\MSBuild\Current\Bin\msbuild.exe" "%Root%bin\%BuildConfiguration%"
 if ERRORLEVEL 1 (
     echo.
     call :PrintColor Red "Signing failed"


### PR DESCRIPTION
MSBuild.exe is now under a directory named "Current" rather than one
with the MSBuild version number.