### PR TITLE
Update signing approach

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -85,7 +85,7 @@ echo.
 call :PrintColor Green "Build completed successfully, for full log see %LogFile%"
 
 if "%RunTests%" == "false" (
-    goto :Signing
+    exit /b 0
 )
 
 echo.
@@ -97,30 +97,6 @@ if ERRORLEVEL 1 (
     exit /b 1
 )
 
-:Signing
-if NOT "%OfficialBuild%" == "true" (
-    exit /b 0
-)
-
-echo.
-echo Signing binaries
-
-REM Respect the %NUGET_PACKAGES% environment variable if set, as that's where nuget will restore to
-set NuGetHome=%NUGET_PACKAGES%
-if "%NuGetHome%" == "" (
-    REM If it's not set, the nuget cache is in the user's home dir
-    set NuGetHome=%UserProfile%\.nuget\packages
-)
-set SignTool="%NuGetHome%\roslyntools.signtool\1.1.0-beta3.21260.1\tools\SignTool.exe"
-
-%SignTool% -config "%Root%build\Signing\SignToolConfig.json" -msbuildPath "%VS160COMNTOOLS%..\..\MSBuild\Current\Bin\msbuild.exe" "%Root%bin\%BuildConfiguration%"
-if ERRORLEVEL 1 (
-    echo.
-    call :PrintColor Red "Signing failed"
-    exit /b 1
-)
-
-call :PrintColor Green "Signing completed. See output Binaries in %Root%build\%BuildConfiguration%"
 exit /b 0
 
 :Usage

--- a/src/ProjectFileTools.MSBuild/ProjectFileTools.MSBuild.csproj
+++ b/src/ProjectFileTools.MSBuild/ProjectFileTools.MSBuild.csproj
@@ -4,12 +4,21 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.3.0-preview-000117-01" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.0.26606-alpha" />
     <Reference Update="**\Microsoft.Language.Xml.dll" CopyLocal="true" />
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+      <Authenticode>MicrosoftSHA2</Authenticode>
+      <StrongName>MsSharedLib72</StrongName>
+    </FilesToSign>
   </ItemGroup>
 
   <Target Name="BuiltProjectOutputGroup" />

--- a/src/ProjectFileTools.NuGetSearch/ProjectFileTools.NuGetSearch.csproj
+++ b/src/ProjectFileTools.NuGetSearch/ProjectFileTools.NuGetSearch.csproj
@@ -10,6 +10,9 @@
     <Company>Microsoft</Company>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Net.Http" />
@@ -18,6 +21,12 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+      <Authenticode>MicrosoftSHA2</Authenticode>
+      <StrongName>MsSharedLib72</StrongName>
+    </FilesToSign>
   </ItemGroup>
   <Target Name="BuiltProjectOutputGroup" />
   <Target Name="BuiltProjectOutputGroupDependencies" />

--- a/src/ProjectFileTools/ProjectFileTools.csproj
+++ b/src/ProjectFileTools/ProjectFileTools.csproj
@@ -160,6 +160,15 @@
       <ManifestResourceName>VSPackage</ManifestResourceName>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+      <Authenticode>MicrosoftSHA2</Authenticode>
+      <StrongName>MsSharedLib72</StrongName>
+    </FilesToSign>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).vsix">
+      <Authenticode>VsixSHA2</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">

--- a/src/ProjectFileTools/project.json
+++ b/src/ProjectFileTools/project.json
@@ -34,6 +34,7 @@
     "Microsoft.VisualStudio.Threading": "15.8.132",
     "Microsoft.VisualStudio.Utilities": "15.7.27703",
     "Microsoft.VisualStudio.Validation": "15.3.58",
+    "Microsoft.VisualStudioEng.MicroBuild.Core": "0.4.1",
     "Microsoft.VSSDK.BuildTools": "15.7.109",
     "Microsoft.Win32.Primitives": "4.3.0",
     "Newtonsoft.Json": "11.0.2",


### PR DESCRIPTION
Set up to use the latest version of MicroBuild signing:
1. Remove the use of RoslynTools.SignTool in build.cmd. This should no longer be necessary, as MicroBuild signing is integrated into MSBuild.
2. Include the Microsoft.VisualStudioEng.MicroBuild.Core package into all the projects that need signing.
3. Define `FilesToSign` items specifying the files that need to be signed by MicroBuild.

Note that in local builds we should still get "public" signing courtesy of the settings in build/Signing/Signing.props. "Real" builds will first apply delay signing, and then MicroBuild will complete the signing.

A future commit will remove the other parts of the current signing infrastructure that we no longer need.